### PR TITLE
Add transition duration, stroke width controls, and global clock style

### DIFF
--- a/docs/Conversation.md
+++ b/docs/Conversation.md
@@ -512,3 +512,41 @@ Completed Issue #23 — Persistent nav bar with view switching:
   - `.app-content` added with `padding-top: 56px` to clear fixed nav bar
 - TypeScript and Vite build verified clean
 - Committed and pushed, closing issue #23
+
+### User
+> Add a PR to add to the clock view the algorithm duration. Then add the following new features. 1. In the playground, I would like to be able to change the width of the hands (second, minute and hour) and also the clock face and tick marks. 2. I would like to be able to use the playground to set the display and colors for all clocks in the app, so there should be a save button that saves the color and display configuration from the playground and replicates that across all clocks in the app.
+
+### Assistant
+Created three issues and implemented all on a feature branch `feature/clock-style-controls`:
+
+**Issue #24 — Transition duration control for ClockScreen:**
+- Replaced hardcoded `TRANSITION_DURATION = 600` with stateful `duration` + preset buttons
+- Duration presets: 300ms, 600ms, 1s, 1.5s, 2s
+- Added Duration row to controls panel (between Algorithm and Speed rows)
+- Duration wired into `animateTo` calls
+
+**Issue #25 — Hand width and stroke controls in ClockPlayground:**
+- Extended `AnalogClockProps` with 6 new stroke width props:
+  - `hourHandWidth` (default 4), `minuteHandWidth` (default 2.5), `secondHandWidth` (default 1)
+  - `faceStrokeWidth` (default 1.5), `tickStrokeWidth` (default 1), `cardinalTickStrokeWidth` (default 2)
+- Added "Stroke Widths" fieldset to ClockPlayground with slider controls (0.5 step)
+- Updated `SliderControl` to accept `step` prop
+- AnalogClock SVG elements now use inline style for both color and stroke width
+
+**Issue #26 — Global clock style context:**
+- Created `src/contexts/ClockStyleContext.tsx`:
+  - `ClockStyle` interface: colors + stroke widths + display toggles
+  - `ClockStyleProvider`: wraps app, manages global style state
+  - `useClockStyle()` hook for consuming the context
+  - Persists to `localStorage` under `clockart-global-style` key
+  - `loadStyle()` merges stored JSON with defaults for forward compatibility
+- Wrapped `App` in `<ClockStyleProvider>`
+- AnalogClock now consumes context: `useClockStyle()` provides defaults, explicit props override
+- ClockPlayground:
+  - "Save as Global Style" button extracts style from playground state → context + localStorage
+  - "Reset All" resets both playground state and global style
+  - `saved` state shows "✓ Saved" confirmation, resets on any change
+- Styled `.save-global-btn` (dark, prominent) and `.playground-actions` row
+
+Created PR with all three features.
+- TypeScript and Vite build verified clean

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import DigitGrid from './components/DigitGrid/DigitGrid'
 import ClockScreen from './components/ClockScreen/ClockScreen'
 import NavBar from './components/NavBar/NavBar'
 import type { ViewKey } from './components/NavBar/NavBar'
+import { ClockStyleProvider } from './contexts/ClockStyleContext'
 import { DIGITS } from './data/digits'
 
 const ALL_DIGITS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
@@ -28,44 +29,46 @@ function App() {
   const [activeView, setActiveView] = useState<ViewKey>(getInitialView)
 
   return (
-    <div className="app">
-      <NavBar activeView={activeView} onViewChange={setActiveView} />
-      <div className="app-content">
-        {activeView === 'clock' && <ClockScreen />}
-        {activeView === 'grid' && <DigitGrid />}
-        {activeView === 'playground' && <ClockPlayground />}
-        {activeView === 'realtime' && (
-          <div className="realtime-container">
-            <AnalogClock
-              size={300}
-              realTime={true}
-              showSecondHand={true}
-              showTickMarks={true}
-            />
-          </div>
-        )}
-        {activeView === 'gallery' && (
-          <div className="all-digits">
-            {ALL_DIGITS.map((digit) => (
-              <div key={digit} className="digit-column">
-                <div className="digit-label">{digit}</div>
-                <div className="digit-grid">
-                  {DIGITS[digit].map((clock, i) => (
-                    <AnalogClock
-                      key={i}
-                      size={80}
-                      hourAngleDeg={clock.hour}
-                      minuteAngleDeg={clock.minute}
-                      showSecondHand={false}
-                    />
-                  ))}
+    <ClockStyleProvider>
+      <div className="app">
+        <NavBar activeView={activeView} onViewChange={setActiveView} />
+        <div className="app-content">
+          {activeView === 'clock' && <ClockScreen />}
+          {activeView === 'grid' && <DigitGrid />}
+          {activeView === 'playground' && <ClockPlayground />}
+          {activeView === 'realtime' && (
+            <div className="realtime-container">
+              <AnalogClock
+                size={300}
+                realTime={true}
+                showSecondHand={true}
+                showTickMarks={true}
+              />
+            </div>
+          )}
+          {activeView === 'gallery' && (
+            <div className="all-digits">
+              {ALL_DIGITS.map((digit) => (
+                <div key={digit} className="digit-column">
+                  <div className="digit-label">{digit}</div>
+                  <div className="digit-grid">
+                    {DIGITS[digit].map((clock, i) => (
+                      <AnalogClock
+                        key={i}
+                        size={80}
+                        hourAngleDeg={clock.hour}
+                        minuteAngleDeg={clock.minute}
+                        showSecondHand={false}
+                      />
+                    ))}
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        )}
+              ))}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </ClockStyleProvider>
   )
 }
 

--- a/src/components/AnalogClock/AnalogClock.tsx
+++ b/src/components/AnalogClock/AnalogClock.tsx
@@ -1,5 +1,6 @@
 import './AnalogClock.css'
 import { useCurrentTime } from '../../hooks/useCurrentTime'
+import { useClockStyle } from '../../contexts/ClockStyleContext'
 
 interface AnalogClockProps {
   // Time-based positioning
@@ -25,6 +26,13 @@ interface AnalogClockProps {
   secondHandColor?: string
   tickColor?: string
   faceColor?: string
+  // Stroke width customization
+  hourHandWidth?: number
+  minuteHandWidth?: number
+  secondHandWidth?: number
+  faceStrokeWidth?: number
+  tickStrokeWidth?: number
+  cardinalTickStrokeWidth?: number
 }
 
 const VIEWBOX_SIZE = 200
@@ -48,20 +56,44 @@ function AnalogClock({
   hourAngleDeg,
   minuteAngleDeg,
   secondAngleDeg,
-  showSecondHand = true,
-  showTickMarks = true,
-  showCardinalTicks = true,
-  showRegularTicks = true,
+  showSecondHand: showSecondHandProp,
+  showTickMarks: showTickMarksProp,
+  showCardinalTicks: showCardinalTicksProp,
+  showRegularTicks: showRegularTicksProp,
   size = '100%',
   realTime = false,
-  hourHandColor,
-  minuteHandColor,
-  secondHandColor,
-  tickColor,
-  faceColor,
+  hourHandColor: hourHandColorProp,
+  minuteHandColor: minuteHandColorProp,
+  secondHandColor: secondHandColorProp,
+  tickColor: tickColorProp,
+  faceColor: faceColorProp,
+  hourHandWidth: hourHandWidthProp,
+  minuteHandWidth: minuteHandWidthProp,
+  secondHandWidth: secondHandWidthProp,
+  faceStrokeWidth: faceStrokeWidthProp,
+  tickStrokeWidth: tickStrokeWidthProp,
+  cardinalTickStrokeWidth: cardinalTickStrokeWidthProp,
 }: AnalogClockProps) {
   // Get current time (only used when realTime is true)
   const currentTime = useCurrentTime()
+
+  // Global style context — props override context values
+  const { style: globalStyle } = useClockStyle()
+  const hourHandColor = hourHandColorProp ?? globalStyle.hourHandColor
+  const minuteHandColor = minuteHandColorProp ?? globalStyle.minuteHandColor
+  const secondHandColor = secondHandColorProp ?? globalStyle.secondHandColor
+  const tickColor = tickColorProp ?? globalStyle.tickColor
+  const faceColor = faceColorProp ?? globalStyle.faceColor
+  const hourHandWidth = hourHandWidthProp ?? globalStyle.hourHandWidth
+  const minuteHandWidth = minuteHandWidthProp ?? globalStyle.minuteHandWidth
+  const secondHandWidth = secondHandWidthProp ?? globalStyle.secondHandWidth
+  const faceStrokeWidth = faceStrokeWidthProp ?? globalStyle.faceStrokeWidth
+  const tickStrokeWidth = tickStrokeWidthProp ?? globalStyle.tickStrokeWidth
+  const cardinalTickStrokeWidth = cardinalTickStrokeWidthProp ?? globalStyle.cardinalTickStrokeWidth
+  const showSecondHand = showSecondHandProp ?? true
+  const showTickMarks = showTickMarksProp ?? globalStyle.showTickMarks
+  const showCardinalTicks = showCardinalTicksProp ?? globalStyle.showCardinalTicks
+  const showRegularTicks = showRegularTicksProp ?? globalStyle.showRegularTicks
 
   // Use real time if enabled, otherwise use props
   const hours = realTime ? currentTime.hours : propHours
@@ -102,7 +134,7 @@ function AnalogClock({
         cy={CENTER}
         r={FACE_RADIUS}
         className="clock-face"
-        style={faceColor ? { stroke: faceColor } : undefined}
+        style={{ stroke: faceColor, strokeWidth: faceStrokeWidth }}
       />
 
       {/* Tick marks */}
@@ -119,7 +151,10 @@ function AnalogClock({
               x2={tick.x2}
               y2={tick.y2}
               className={tick.isCardinal ? 'tick tick-cardinal' : 'tick'}
-              style={tickColor ? { stroke: tickColor } : undefined}
+              style={{
+                stroke: tickColor,
+                strokeWidth: tick.isCardinal ? cardinalTickStrokeWidth : tickStrokeWidth,
+              }}
             />
           )
         })}
@@ -132,7 +167,7 @@ function AnalogClock({
         y2={CENTER - HAND_HOUR_LENGTH}
         className="hand hand-hour"
         transform={`rotate(${hourAngle}, ${CENTER}, ${CENTER})`}
-        style={hourHandColor ? { stroke: hourHandColor } : undefined}
+        style={{ stroke: hourHandColor, strokeWidth: hourHandWidth }}
       />
 
       {/* Minute hand */}
@@ -143,7 +178,7 @@ function AnalogClock({
         y2={CENTER - HAND_MINUTE_LENGTH}
         className="hand hand-minute"
         transform={`rotate(${minuteAngle}, ${CENTER}, ${CENTER})`}
-        style={minuteHandColor ? { stroke: minuteHandColor } : undefined}
+        style={{ stroke: minuteHandColor, strokeWidth: minuteHandWidth }}
       />
 
       {/* Second hand */}
@@ -155,7 +190,7 @@ function AnalogClock({
           y2={CENTER - HAND_SECOND_LENGTH}
           className="hand hand-second"
           transform={`rotate(${secondAngle}, ${CENTER}, ${CENTER})`}
-          style={secondHandColor ? { stroke: secondHandColor } : undefined}
+          style={{ stroke: secondHandColor, strokeWidth: secondHandWidth }}
         />
       )}
     </svg>

--- a/src/components/ClockPlayground/ClockPlayground.css
+++ b/src/components/ClockPlayground/ClockPlayground.css
@@ -148,6 +148,30 @@
   cursor: pointer;
 }
 
+/* Action buttons row */
+.playground-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+/* Save global style button */
+.save-global-btn {
+  padding: 8px 16px;
+  border: 1px solid #333;
+  border-radius: 6px;
+  background: #333;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  color: #fff;
+  transition: background-color 0.15s;
+}
+
+.save-global-btn:hover {
+  background: #555;
+}
+
 /* Reset button */
 .reset-btn {
   padding: 8px 16px;
@@ -158,7 +182,6 @@
   cursor: pointer;
   color: #555;
   transition: background-color 0.15s;
-  align-self: flex-start;
 }
 
 .reset-btn:hover {

--- a/src/components/ClockScreen/ClockScreen.tsx
+++ b/src/components/ClockScreen/ClockScreen.tsx
@@ -32,7 +32,7 @@ function timeToDigits(hours: number, minutes: number): [string, string, string, 
 const CLOCK_SIZE = 80
 const CLOCK_GAP = 2
 const GRID_HEIGHT = CLOCK_SIZE * 3 + CLOCK_GAP * 2
-const TRANSITION_DURATION = 600
+const DURATION_PRESETS = [300, 600, 1000, 1500, 2000]
 
 const SPEED_PRESETS = [1, 2, 5, 10, 30, 60]
 const ALGORITHM_KEYS = Object.keys(ALGORITHMS) as AlgorithmKey[]
@@ -40,6 +40,7 @@ const ALGORITHM_KEYS = Object.keys(ALGORITHMS) as AlgorithmKey[]
 function ClockScreen() {
   const { time, setTime, setNow, speed, setSpeed } = useClockTime()
   const [algorithm, setAlgorithm] = useState<AlgorithmKey>('shortest')
+  const [duration, setDuration] = useState(600)
 
   // Refs for HH:MM digit displays
   const h1Ref = useRef<DigitDisplayHandle>(null)
@@ -62,12 +63,12 @@ function ClockScreen() {
 
     for (let i = 0; i < 4; i++) {
       if (curr[i] !== prev[i] && refs[i].current) {
-        refs[i].current!.animateTo(curr[i], strategy, TRANSITION_DURATION)
+        refs[i].current!.animateTo(curr[i], strategy, duration)
       }
     }
 
     prevDigitsRef.current = curr
-  }, [h1, h2, m1, m2, algorithm])
+  }, [h1, h2, m1, m2, algorithm, duration])
 
   return (
     <div className="clock-screen">
@@ -127,6 +128,21 @@ function ClockScreen() {
                 onClick={() => setAlgorithm(key)}
               >
                 {ALGORITHMS[key].label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="clock-controls-row">
+          <span className="clock-controls-label">Duration</span>
+          <div className="clock-btn-group">
+            {DURATION_PRESETS.map((d) => (
+              <button
+                key={d}
+                className={duration === d ? 'clock-btn active' : 'clock-btn'}
+                onClick={() => setDuration(d)}
+              >
+                {d >= 1000 ? `${d / 1000}s` : `${d}ms`}
               </button>
             ))}
           </div>

--- a/src/contexts/ClockStyleContext.tsx
+++ b/src/contexts/ClockStyleContext.tsx
@@ -1,0 +1,109 @@
+import { createContext, useContext, useState, useCallback, useEffect } from 'react'
+import type { ReactNode } from 'react'
+
+/** The visual style properties that can be saved globally */
+export interface ClockStyle {
+  // Colors
+  hourHandColor: string
+  minuteHandColor: string
+  secondHandColor: string
+  tickColor: string
+  faceColor: string
+  // Stroke widths
+  hourHandWidth: number
+  minuteHandWidth: number
+  secondHandWidth: number
+  faceStrokeWidth: number
+  tickStrokeWidth: number
+  cardinalTickStrokeWidth: number
+  // Display toggles
+  showTickMarks: boolean
+  showCardinalTicks: boolean
+  showRegularTicks: boolean
+}
+
+export const DEFAULT_CLOCK_STYLE: ClockStyle = {
+  hourHandColor: '#333333',
+  minuteHandColor: '#333333',
+  secondHandColor: '#e74c3c',
+  tickColor: '#333333',
+  faceColor: '#333333',
+  hourHandWidth: 4,
+  minuteHandWidth: 2.5,
+  secondHandWidth: 1,
+  faceStrokeWidth: 1.5,
+  tickStrokeWidth: 1,
+  cardinalTickStrokeWidth: 2,
+  showTickMarks: true,
+  showCardinalTicks: true,
+  showRegularTicks: true,
+}
+
+interface ClockStyleContextValue {
+  style: ClockStyle
+  setStyle: (style: ClockStyle) => void
+  resetStyle: () => void
+}
+
+const ClockStyleContext = createContext<ClockStyleContextValue>({
+  style: DEFAULT_CLOCK_STYLE,
+  setStyle: () => {},
+  resetStyle: () => {},
+})
+
+const STORAGE_KEY = 'clockart-global-style'
+
+function loadStyle(): ClockStyle {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored)
+      // Merge with defaults to handle any missing keys from older versions
+      return { ...DEFAULT_CLOCK_STYLE, ...parsed }
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return DEFAULT_CLOCK_STYLE
+}
+
+export function ClockStyleProvider({ children }: { children: ReactNode }) {
+  const [style, setStyleState] = useState<ClockStyle>(loadStyle)
+
+  const setStyle = useCallback((newStyle: ClockStyle) => {
+    setStyleState(newStyle)
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(newStyle))
+    } catch {
+      // Ignore storage errors
+    }
+  }, [])
+
+  const resetStyle = useCallback(() => {
+    setStyleState(DEFAULT_CLOCK_STYLE)
+    try {
+      localStorage.removeItem(STORAGE_KEY)
+    } catch {
+      // Ignore storage errors
+    }
+  }, [])
+
+  // Sync to storage on mount if loaded from storage
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      setStyleState(loadStyle())
+    }
+  }, [])
+
+  return (
+    <ClockStyleContext.Provider value={{ style, setStyle, resetStyle }}>
+      {children}
+    </ClockStyleContext.Provider>
+  )
+}
+
+/** Hook to access the global clock style */
+export function useClockStyle(): ClockStyleContextValue {
+  return useContext(ClockStyleContext)
+}


### PR DESCRIPTION
## Summary
- **Transition duration control** (#24): ClockScreen now has a Duration row with preset buttons (300ms, 600ms, 1s, 1.5s, 2s) instead of a hardcoded 600ms
- **Stroke width customization** (#25): AnalogClock accepts stroke width props for all elements (hands, face, ticks). ClockPlayground adds a "Stroke Widths" fieldset with slider controls
- **Global clock style context** (#26): New `ClockStyleContext` with localStorage persistence. Playground's "Save as Global Style" button applies colors, stroke widths, and display toggles across all clocks in every view. Playground initializes from saved global style when re-visited

## Test plan
- [ ] Open Clock view → verify Duration row appears with 5 presets, changing duration affects animation speed
- [ ] Open Playground → verify Stroke Widths fieldset with 6 sliders, preview updates in real time
- [ ] In Playground, change colors/widths → click "Save as Global Style" → switch to Clock/Grid/Gallery views → verify all clocks reflect saved style
- [ ] Reload the page → verify saved style persists from localStorage
- [ ] In Playground, click "Reset All" → verify playground and all views return to defaults
- [ ] Switch away from Playground and back → verify it retains the saved global style values

🤖 Generated with [Claude Code](https://claude.com/claude-code)